### PR TITLE
update make files to use standard cuda path (version agnostic)

### DIFF
--- a/KernelAndLibExamples/vector_add/Makefile
+++ b/KernelAndLibExamples/vector_add/Makefile
@@ -1,7 +1,7 @@
 all: hw
 
 hw:
-	 nvcc -x cu -O3 -std=c++20 -arch=sm_86 -I/usr/local/cuda-12.3/bin/../include ./vector_add.cu -o main -L/usr/local/cuda-12.3/bin/../lib64
+	 nvcc -x cu -O3 -std=c++20 -arch=sm_86 -I/usr/local/cuda/bin/../include ./vector_add.cu -o main -L/usr/local/cuda/bin/../lib64
 
 clean:
 	rm -f main

--- a/MemoryAndStructureExamples/alloc_init_vs_alloc_uninit/Makefile
+++ b/MemoryAndStructureExamples/alloc_init_vs_alloc_uninit/Makefile
@@ -1,7 +1,7 @@
 all: hw
 
 hw:
-	 nvcc -x cu -O3 -std=c++20 -arch=sm_86 -I/usr/local/cuda-12.3/bin/../include ./alloc_init_vs_alloc_uninit.cu -o main -L/usr/local/cuda-12.3/bin/../lib64
+	 nvcc -x cu -O3 -std=c++20 -arch=sm_86 -I/usr/local/cuda/bin/../include ./alloc_init_vs_alloc_uninit.cu -o main -L/usr/local/cuda/bin/../lib64
 
 clean:
 	rm -f main

--- a/MemoryAndStructureExamples/pinned_vs_pageable/Makefile
+++ b/MemoryAndStructureExamples/pinned_vs_pageable/Makefile
@@ -1,7 +1,7 @@
 all: hw
 
 hw:
-	 nvcc -x cu -O3 -std=c++20 -arch=sm_86 -I/usr/local/cuda-12.3/bin/../include ./pinned_vs_pageable.cu -o main -L/usr/local/cuda-12.3/bin/../lib64
+	 nvcc -x cu -O3 -std=c++20 -arch=sm_86 -I/usr/local/cuda/bin/../include ./pinned_vs_pageable.cu -o main -L/usr/local/cuda/bin/../lib64
 
 clean:
 	rm -f main

--- a/PerformanceChecklistExamples/cuda_streams/Makefile
+++ b/PerformanceChecklistExamples/cuda_streams/Makefile
@@ -1,7 +1,7 @@
 all: hw
 
 hw:
-	 nvcc -x cu -O3 -std=c++20 -arch=sm_86 -I/usr/local/cuda-12.3/bin/../include ./cuda_streams.cu -o main -L/usr/local/cuda-12.3/bin/../lib64
+	 nvcc -x cu -O3 -std=c++20 -arch=sm_86 -I/usr/local/cuda/bin/../include ./cuda_streams.cu -o main -L/usr/local/cuda/bin/../lib64
 
 clean:
 	rm -f main

--- a/ProfilingExamples/bandwidth_check/Makefile
+++ b/ProfilingExamples/bandwidth_check/Makefile
@@ -1,7 +1,7 @@
 all: hw
 
 hw:
-	 nvcc -x cu -O3 -std=c++20 -arch=sm_86 -I/usr/local/cuda-12.3/bin/../include ./bandwidth_check.cu -o main -L/usr/local/cuda-12.3/bin/../lib64
+	 nvcc -x cu -O3 -std=c++20 -arch=sm_86 -I/usr/local/cuda/bin/../include ./bandwidth_check.cu -o main -L/usr/local/cuda/bin/../lib64
 
 clean:
 	rm -f main

--- a/ProfilingExamples/global_vs_shared_mem/Makefile
+++ b/ProfilingExamples/global_vs_shared_mem/Makefile
@@ -1,7 +1,7 @@
 all: hw
 
 hw:
-	 nvcc -x cu -O3 -std=c++20 -arch=sm_86 -I/usr/local/cuda-12.3/bin/../include ./global_vs_shared.cu -o main -L/usr/local/cuda/bin/../lib64
+	 nvcc -x cu -O3 -std=c++20 -arch=sm_86 -I/usr/local/cuda/bin/../include ./global_vs_shared.cu -o main -L/usr/local/cuda/bin/../lib64
 
 clean:
 	rm -f main

--- a/ProfilingExamples/memory_bank_conflict/Makefile
+++ b/ProfilingExamples/memory_bank_conflict/Makefile
@@ -1,7 +1,7 @@
 all: hw
 
 hw:
-	 nvcc -x cu -O3 -std=c++20 -arch=sm_86 -I/usr/local/cuda-12.3/bin/../include ./bank_conflict.cu -o main -L/usr/local/cuda/bin/../lib64
+	 nvcc -x cu -O3 -std=c++20 -arch=sm_86 -I/usr/local/cuda/bin/../include ./bank_conflict.cu -o main -L/usr/local/cuda/bin/../lib64
 
 clean:
 	rm -f main

--- a/ProfilingExamples/nvtx/Makefile
+++ b/ProfilingExamples/nvtx/Makefile
@@ -1,7 +1,7 @@
 all: hw
 
 hw:
-	 nvcc -x cu -O3 -std=c++20 -arch=sm_86 -I/usr/local/cuda-12.3/bin/../include ./nvtx_example.cu -o main -L/usr/local/cuda-12.3/bin/../lib64 -lnvToolsExt
+	 nvcc -x cu -O3 -std=c++20 -arch=sm_86 -I/usr/local/cuda/bin/../include ./nvtx_example.cu -o main -L/usr/local/cuda/bin/../lib64 -lnvToolsExt
 
 clean:
 	rm -f main

--- a/SetupAndInitExamples/setup_check/Makefile
+++ b/SetupAndInitExamples/setup_check/Makefile
@@ -1,7 +1,7 @@
 all: hw
 
 hw:
-	 nvcc -x cu -O3 -std=c++20 -arch=sm_86 -I/usr/local/cuda-12.3/bin/../include ./hello_world.cu -o main -L/usr/local/cuda-12.3/bin/../lib64
+	 nvcc -x cu -O3 -std=c++20 -arch=sm_86 -I/usr/local/cuda/bin/../include ./hello_world.cu -o main -L/usr/local/cuda/bin/../lib64
 
 clean:
 	rm -f main

--- a/TensorParallelFromScratch/01_simple_matmul_no_tp/Makefile
+++ b/TensorParallelFromScratch/01_simple_matmul_no_tp/Makefile
@@ -1,7 +1,7 @@
 all: hw
 
 hw:
-	 nvcc -x cu -O3 -std=c++20 -arch=sm_86 -I/usr/local/cuda-12/bin/../include ./matmul.cu -o main -L/usr/local/cuda-12/bin/../lib64
+	 nvcc -x cu -O3 -std=c++20 -arch=sm_86 -I/usr/local/cuda/bin/../include ./matmul.cu -o main -L/usr/local/cuda/bin/../lib64
 
 clean:
 	rm -f main


### PR DESCRIPTION
Use Cuda standard path in make files to avoid tool kit version mismatching